### PR TITLE
add support of sample step

### DIFF
--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -87,6 +87,7 @@ import MediaElementWebAudio from './mediaelement-webaudio';
  * `'audio'|'video'` ('video' only for `MediaElement`)
  * @property {number} minPxPerSec=20 Minimum number of pixels per second of
  * audio.
+ * @property {number} sampleStep=null If set, use the sampleStep in webaudio. Default behavior is to use ~~(sampleSize / 10).
  * @property {boolean} normalize=false If true, normalize by the maximum peak
  * instead of 1.0.
  * @property {boolean} partialRender=false Use the PeakCache to improve
@@ -278,6 +279,7 @@ export default class WaveSurfer extends util.Observer {
         mediaControls: false,
         mediaType: 'audio',
         minPxPerSec: 20,
+        sampleStep: null,
         normalize: false,
         partialRender: false,
         pixelRatio:

--- a/src/webaudio.js
+++ b/src/webaudio.js
@@ -444,19 +444,17 @@ export default class WebAudio extends util.Observer {
             this.buffer = newBuffer.buffer;
         }
 
-        const sampleSize = this.buffer.length / length;
-        const sampleStep = ~~(sampleSize / 10) || 1;
+        const sampleSize = ~~(this.buffer.length / length);
+        const sampleStep = this.params.sampleStep ? this.params.sampleStep : (~~(sampleSize / 10) || 1);
         const channels = this.buffer.numberOfChannels;
         let c;
-
         for (c = 0; c < channels; c++) {
             const peaks = this.splitPeaks[c];
             const chan = this.buffer.getChannelData(c);
             let i;
-
             for (i = first; i <= last; i++) {
-                const start = ~~(i * sampleSize);
-                const end = ~~(start + sampleSize);
+                const start = i * sampleSize;
+                const end = start + sampleSize;
                 /**
                  * Initialize the max and min to the first sample of this
                  * subrange, so that even if the samples are entirely
@@ -472,9 +470,7 @@ export default class WebAudio extends util.Observer {
 
                     if (value > max) {
                         max = value;
-                    }
-
-                    if (value < min) {
+                    } else if (value < min) {
                         min = value;
                     }
                 }


### PR DESCRIPTION
add support of sample step for webaudio.js
When displaying a long audio waveform in "scrollParent:false" mode, some information will be lost due to the strategy, which makes the waveform look different from that on some PC software. With this option,  when the user passes in 1, the waveform display effect is the same as that on the PC software. This option sacrifices some of the performance for an accurate presentation.

### Breaking in the external API:
no

### Breaking changes in the internal API:
no
