### PR TITLE
Markers Plugin: Inherit `font-family` rather than setting `monospace`

### DIFF
--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -274,7 +274,7 @@ export default class MarkersPlugin {
             labelEl.innerText = label;
             labelEl.setAttribute('title', tooltip);
             this.style(labelEl, {
-                "font-family": "monospace",
+                "font-family": "inherit",
                 "font-size": "90%"
             });
             labelDiv.appendChild(labelEl);


### PR DESCRIPTION
## Please make sure you provide the information below:

### Short description of changes:
As a user, I would like to customize the font for labels that I add to markers. However, I am unable to assign a property from the top level component due to the specified font-family in the label element. 

#### Screenshot of demonstrated issue
<img width="332" alt="Screenshot 2023-02-10 at 4 57 28 PM" src="https://user-images.githubusercontent.com/20084278/218228486-5d1e27b8-2f59-401c-a2c1-7fc3d02f5fef.png">

#### Code snippet where I try to modify the font-family
```tsx
<Box
  ref={waveformRef}
  gap={2}
  sx={{
    maxWidth: '189px', // TODO: Can we not fix this?
    display: 'flex',
    alignItems: 'center',
    span: {
      color: theme.palette.primary.main,
      marginTop: '-13px',
      fontFamily: theme.typography.fontFamily,
    }
  }}
/>
```

### Breaking in the external API:


### Breaking changes in the internal API:


### Todos/Notes:
This is my first PR in this repository! Please let me know if I missed something!

### Related Issues and other PRs:
