### PR TITLE
Fix iphone silent switch webaudio mute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ wavesurfer.js changelog
 ------------------
 - Regions plugin:
   - Improved delta calculation (resize end) (#2641)
+- Fix iphone silent switch webaudio mute (#2667)
 
 6.4.0 (05.11.2022)
 ------------------

--- a/src/util/silence-mode.js
+++ b/src/util/silence-mode.js
@@ -11,8 +11,8 @@
  */
 export default function ignoreSilenceMode() {
     // Set webaudio context with 1 second silent audio 44100 bit rate buffer to allow playing audio even if silent switch is on the device
-    let silentAC = new AudioContext();
-    let silentBS = silentAC.createBufferSource();
+    const silentAC = new AudioContext();
+    const silentBS = silentAC.createBufferSource();
     silentBS.buffer = silentAC.createBuffer(1, 1, 44100);
     silentBS.connect(silentAC.destination);
     silentBS.start();

--- a/src/util/silence-mode.js
+++ b/src/util/silence-mode.js
@@ -10,6 +10,13 @@
  * @since 5.2.0
  */
 export default function ignoreSilenceMode() {
+    // Set webaudio context with 1 second silent audio 44100 bit rate buffer to allow playing audio even if silent switch is on the device 
+    let silentAC = new AudioContext();
+    let silentBS = silentAC.createBufferSource();
+    silentBS.buffer = silentAC.createBuffer(1, 1, 44100);
+    silentBS.connect(silentAC.destination);
+    silentBS.start();
+
     // Set the src to a short bit of url encoded as a silent mp3
     // NOTE The silence MP3 must be high quality, when web audio sounds are played
     // in parallel the web audio sound is mixed to match the bitrate of the html sound

--- a/src/util/silence-mode.js
+++ b/src/util/silence-mode.js
@@ -10,7 +10,7 @@
  * @since 5.2.0
  */
 export default function ignoreSilenceMode() {
-    // Set webaudio context with 1 second silent audio 44100 bit rate buffer to allow playing audio even if silent switch is on the device 
+    // Set webaudio context with 1 second silent audio 44100 bit rate buffer to allow playing audio even if silent switch is on the device
     let silentAC = new AudioContext();
     let silentBS = silentAC.createBufferSource();
     silentBS.buffer = silentAC.createBuffer(1, 1, 44100);


### PR DESCRIPTION
fixes #2667 

adds a 1 second webaudio context buffer with 44100 bit rate to allow audio to play even if iphone silent switch is turned on.

preview here using latest wavesurfer.js version 6.4.0
https://www.entonbiba.com/lab/wavesurfer/2667.html

closes #2667 