### PR TITLE
Proxy HTMLMediaElement's 'waiting' event through MediaElement backend.

### DIFF
--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -65,7 +65,7 @@ export default class MediaElement extends WebAudio {
         this.mediaListeners.error = () => {
             this.fireEvent('error', 'Error loading media element');
         };
-        this.mediaListeners.canplay = () => {
+        this.mediaListeners.waiting = () => {
             this.fireEvent('waiting');
         };
         this.mediaListeners.canplay = () => {

--- a/src/mediaelement.js
+++ b/src/mediaelement.js
@@ -66,6 +66,9 @@ export default class MediaElement extends WebAudio {
             this.fireEvent('error', 'Error loading media element');
         };
         this.mediaListeners.canplay = () => {
+            this.fireEvent('waiting');
+        };
+        this.mediaListeners.canplay = () => {
             this.fireEvent('canplay');
         };
         this.mediaListeners.ended = () => {


### PR DESCRIPTION
When using the MediaElement backend, it will be possible to subscribe to 'waiting' event.
This way, one can implement a loading indicator, showing it on 'waiting' and hiding it on 'canplay'.
