### PR TITLE
Update minPxPerSec docs

### DIFF
--- a/docs/options.html
+++ b/docs/options.html
@@ -182,7 +182,7 @@ layout: default
         <td><code>minPxPerSec</code></td>
         <td>integer</td>
         <td><code>50</code></td>
-        <td>Minimum number of pixels per second of audio.</td>
+        <td>Minimum number of pixels per second of audio. Needs `scrollParent: true` or `fillParent: false` to have an effect.</td>
       </tr>
       <tr>
         <td><code>normalize</code></td>


### PR DESCRIPTION
It wasn't trivial to figure out why this option didn't do anything on its own.