### PR TITLE
Add autoCenterImmediately option in the documentation

### DIFF
--- a/docs/options.html
+++ b/docs/options.html
@@ -47,6 +47,12 @@ layout: default
         <td>If a scrollbar is present, center the waveform around the progress.</td>
       </tr>
       <tr>
+        <td><code>autoCenterImmediately</code></td>
+        <td>boolean</td>
+        <td><code>false</code></td>
+        <td>Whether to apply transition effect when seeking waveforms. Useful if you handle large waveforms and the transition is struggling.</td>
+      </tr>
+      <tr>
         <td><code>backend</code></td>
         <td>string</td>
         <td><code>WebAudio</code></td>


### PR DESCRIPTION
I hope that issue #1281 will be resolved in the future, making this option no longer useful.