### PR TITLE
funding: update the sponsorship account

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: [thijstriemstra, katspaugh]
+github: [wavesurfer-js]


### PR DESCRIPTION
Change the sponsorship account to the wavesurfer-js org.