### PR TITLE
Fix: release workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,10 @@ name: NPM Package
 
 on:
   push:
-    branches: [ master ]
+    branches: [ workflow ]
+
+permissions:
+  contents: write
 
 jobs:
   publish-npm:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@ name: NPM Package
 
 on:
   push:
-    branches: [ workflow ]
+    branches: [ master ]
 
 permissions:
   contents: write

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/wavesurfer-js/wavesurfer.js.git"
+    "url": "git@github.com:wavesurfer-js/wavesurfer.js.git"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
The release workflow is failing after migrating the repo to a new org.