### PR TITLE
Docs: add a video tutorial link to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Interactive navigable audio visualization using Web Audio and Canvas.
 
 [![Screenshot](https://raw.githubusercontent.com/wavesurfer-js/wavesurfer.js/gh-pages/example/screenshot.png "Screenshot")](https://wavesurfer-js.org)
 
-See a [tutorial](https://wavesurfer-js.org/docs) and [examples](https://wavesurfer-js.org/examples) on [wavesurfer-js.org](https://wavesurfer-js.org).
+See [docs](https://wavesurfer-js.org/docs) and [examples](https://wavesurfer-js.org/examples) on [wavesurfer-js.org](https://wavesurfer-js.org).
+
+For a video tutorial, watch this [series by Live Blogger on YouTube](https://www.youtube.com/watch?v=yCmnDWCF8m0). 📺
 
 ## Questions
 Have a question about integrating wavesurfer.js on your website? Feel free to ask in our forum: https://github.com/wavesurfer-js/wavesurfer.js/discussions/categories/q-a


### PR DESCRIPTION
There are quite a few video tutorials about wavesurfer.js on youtube.
I picked one from the first page that I think is very good. Kudos to the author!