### PR TITLE
Fix: avoid exit 1 in CI script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,24 +30,30 @@ jobs:
             echo "Version $OLD_VERSION hasn't changed, skipping the release"
           fi
 
-      - name: Create a git tag
-        if: ${{ steps.version.outputs.version }}
-        run: git tag $NEW_VERSION && git push --tags
-        env:
-          NEW_VERSION: ${{ steps.version.outputs.version }}
+      # - name: Create a git tag
+      #   if: ${{ steps.version.outputs.version }}
+      #   run: git tag $NEW_VERSION && git push --tags
+      #   env:
+      #     NEW_VERSION: ${{ steps.version.outputs.version }}
 
-      - name: GitHub release
+      # - name: GitHub release
+      #   if: ${{ steps.version.outputs.version }}
+      #   uses: actions/create-release@v1
+      #   id: create_release
+      #   with:
+      #     draft: false
+      #     prerelease: false
+      #     release_name: ${{ steps.version.outputs.version }}
+      #     tag_name: ${{ steps.version.outputs.version }}
+      #     body_path: TEMP_CHANGELOG.md
+      #   env:
+      #     GITHUB_TOKEN: ${{ github.token }}
+
+      - uses: actions/setup-node@v3
         if: ${{ steps.version.outputs.version }}
-        uses: actions/create-release@v1
-        id: create_release
         with:
-          draft: false
-          prerelease: false
-          release_name: ${{ steps.version.outputs.version }}
-          tag_name: ${{ steps.version.outputs.version }}
-          body_path: TEMP_CHANGELOG.md
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         if: ${{ steps.version.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,6 @@ jobs:
             git log "$OLD_VERSION"..HEAD --pretty=format:"* %s" > TEMP_CHANGELOG.md
           else
             echo "Version $OLD_VERSION hasn't changed, skipping the release"
-            exit 0
           fi
 
       - name: Create a git tag

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - fix-publish
 
 permissions:
   contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,21 +24,21 @@ jobs:
           NEW_VERSION=$(node -p 'require("./package.json").version')
           if [ $NEW_VERSION != $OLD_VERSION ]; then
             echo "New version $NEW_VERSION detected"
-            echo "::set-output name=version::$NEW_VERSION"
+            echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
             git log "$OLD_VERSION"..HEAD --pretty=format:"* %s" > TEMP_CHANGELOG.md
           else
             echo "Version $OLD_VERSION hasn't changed, skipping the release"
-            exit 1
+            exit 0
           fi
 
       - name: Create a git tag
-        if: success()
+        if: ${{ steps.version.outputs.version }}
         run: git tag $NEW_VERSION && git push --tags
         env:
           NEW_VERSION: ${{ steps.version.outputs.version }}
 
       - name: GitHub release
-        if: success()
+        if: ${{ steps.version.outputs.version }}
         uses: actions/create-release@v1
         id: create_release
         with:
@@ -51,11 +51,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
       - name: Install dependencies
-        if: success()
+        if: ${{ steps.version.outputs.version }}
         run: npm install
 
       - name: Publish to NPM
-        if: success()
+        if: ${{ steps.version.outputs.version }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
         run: npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - fix-publish
+      - master
 
 permissions:
   contents: write
@@ -30,24 +30,24 @@ jobs:
             echo "Version $OLD_VERSION hasn't changed, skipping the release"
           fi
 
-      # - name: Create a git tag
-      #   if: ${{ steps.version.outputs.version }}
-      #   run: git tag $NEW_VERSION && git push --tags
-      #   env:
-      #     NEW_VERSION: ${{ steps.version.outputs.version }}
+      - name: Create a git tag
+        if: ${{ steps.version.outputs.version }}
+        run: git tag $NEW_VERSION && git push --tags
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.version }}
 
-      # - name: GitHub release
-      #   if: ${{ steps.version.outputs.version }}
-      #   uses: actions/create-release@v1
-      #   id: create_release
-      #   with:
-      #     draft: false
-      #     prerelease: false
-      #     release_name: ${{ steps.version.outputs.version }}
-      #     tag_name: ${{ steps.version.outputs.version }}
-      #     body_path: TEMP_CHANGELOG.md
-      #   env:
-      #     GITHUB_TOKEN: ${{ github.token }}
+      - name: GitHub release
+        if: ${{ steps.version.outputs.version }}
+        uses: actions/create-release@v1
+        id: create_release
+        with:
+          draft: false
+          prerelease: false
+          release_name: ${{ steps.version.outputs.version }}
+          tag_name: ${{ steps.version.outputs.version }}
+          body_path: TEMP_CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - uses: actions/setup-node@v3
         if: ${{ steps.version.outputs.version }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,9 +3,8 @@ wavesurfer.js changelog
 
 6.6.1 (18.03.2023)
 ------------------
-- Temp: test on this branch
-- Fix: avoid exit 1 in CI script
 - Fix: NPM publish in the CI job (#2727)
+  - Fix: avoid exit 1 in CI script (#2734)
 - Docs: add a video tutorial link to the readme (#2724)
 
 6.6.0 (14.03.2023)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,13 @@
 wavesurfer.js changelog
 =======================
 
+6.6.1 (18.03.2023)
+------------------
+- Temp: test on this branch
+- Fix: avoid exit 1 in CI script
+- Fix: NPM publish in the CI job (#2727)
+- Docs: add a video tutorial link to the readme (#2724)
+
 6.6.0 (14.03.2023)
 ------------------
 - Zoom optimisation for Waves and matching implementation for Spectrograms (#2646)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "homepage": "https://wavesurfer-js.org",
   "authors": [
     "katspaugh <katspaugh@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
   "main": "dist/wavesurfer.js",
   "directories": {


### PR DESCRIPTION
Resolves #2723.

The release workflow intentionally fails when there's no new version to release, but this might look confusing because it looks like it failed due to an error.

Instead of `exit 1`, we're now checking for the new version on each step and exit w/o an error.

Also NPM publish actually wasn't working. @thijstriemstra as you noticed correctly in the dry-run, it was showing an error. Fixed it by adding a setup-node step.