### PR TITLE
feat(MarkersPlugin):  add getMarkers function

### DIFF
--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -70,6 +70,9 @@ export default class MarkersPlugin {
                     }
                     return this.markers.add(options);
                 },
+                getMarkers() {
+                    return this.markers;
+                },
                 clearMarkers() {
                     this.markers && this.markers.clear();
                 }


### PR DESCRIPTION
### Short description of changes:
Add a function to get all current markers to the wavesurfer object.

### Breaking in the external API:
None I guess.

### Breaking changes in the internal API:
None I guess.

### Todos/Notes:
Untested.
I also would like to add it to the regions plugin if this is ok.
This way I dont need to keep track of the state outside of wavesurfer.
Great tool btw, using it for https://gitlab.com/fraggen/fraggen
