### PR TITLE
Revert "Zoom optimisation"

### DIFF
--- a/example/spectrogram/app.js
+++ b/example/spectrogram/app.js
@@ -22,6 +22,15 @@ function initAndLoadSpectrogram(colorMap) {
         ]
     };
 
+    if (location.search.match('scroll')) {
+        options.minPxPerSec = 100;
+        options.scrollParent = true;
+    }
+
+    if (location.search.match('normalize')) {
+        options.normalize = true;
+    }
+
     wavesurfer = WaveSurfer.create(options);
 
     /* Progress bar */
@@ -45,29 +54,6 @@ function initAndLoadSpectrogram(colorMap) {
     })();
 
     wavesurfer.load('../media/demo.wav');
-
-    // Zoom slider
-    let slider = document.querySelector('[data-action="zoom"]');
-
-    slider.value = wavesurfer.params.minPxPerSec;
-    slider.min = wavesurfer.params.minPxPerSec;
-    slider.max = 250;
-
-
-    slider.addEventListener('input', function() {
-        wavesurfer.zooming(slider.value);
-    });
-    slider.addEventListener('mouseup', function() {
-        wavesurfer.zoom(slider.value);
-
-        let desiredWidth = Math.max(parseInt(wavesurfer.container.offsetWidth * window.devicePixelRatio),
-            parseInt(wavesurfer.getDuration() * slider.value * window.devicePixelRatio));
-        wavesurfer.spectrogram.width = desiredWidth;
-        wavesurfer.spectrogram.render();
-    });
-
-    // set initial zoom to match slider value
-    wavesurfer.zoom(slider.value);
 }
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/example/spectrogram/index.html
+++ b/example/spectrogram/index.html
@@ -31,6 +31,13 @@
     <body itemscope itemtype="http://schema.org/WebApplication">
         <div class="container">
             <div class="header">
+                <noindex>
+                <ul class="nav nav-pills pull-right">
+                    <li><a href="?fill">Fill</a></li>
+                    <li><a href="?scroll">Scroll</a></li>
+                </ul>
+                </noindex>
+
                 <h1 itemprop="name"><a href="http://wavesurfer-js.org">wavesurfer.js</a><noindex> + Spectrogram</noindex></h1>
             </div>
 
@@ -52,17 +59,6 @@
                         <i class="glyphicon glyphicon-pause"></i>
                         Pause
                     </button>
-                    <div class="col-sm-1">
-                        <i class="glyphicon glyphicon-zoom-in"></i>
-                    </div>
-    
-                    <div class="col-sm-3">
-                      <input data-action="zoom" type="range" min="1" max="200" value="0" style="width: 100%" />
-                    </div>
-    
-                    <div class="col-sm-1">
-                        <i class="glyphicon glyphicon-zoom-out"></i>
-                    </div>
                 </div>
             </div>
 

--- a/example/zoom/index.html
+++ b/example/zoom/index.html
@@ -82,13 +82,9 @@
     backend: 'MediaElement'
 });
 
-let slider = document.querySelector('[data-action="zoom"]');
-slider.addEventListener('input', function() {
-    wavesurfer.zooming(slider.value);
-});
-slider.addEventListener('mouseup', function() {
-    wavesurfer.zoom(slider.value);
-});
+document.querySelector('#slider').oninput = function () {
+    wavesurfer.zoom(Number(this.value));
+};
 </code></pre>
                 </p>
             </div>

--- a/example/zoom/main.js
+++ b/example/zoom/main.js
@@ -49,9 +49,6 @@ document.addEventListener('DOMContentLoaded', function() {
     slider.max = 1000;
 
     slider.addEventListener('input', function() {
-        wavesurfer.zooming(Number(this.value));
-    });
-    slider.addEventListener('mouseup', function() {
         wavesurfer.zoom(Number(this.value));
     });
 

--- a/src/drawer.canvasentry.js
+++ b/src/drawer.canvasentry.js
@@ -66,11 +66,6 @@ export default class CanvasEntry {
          * @type {object}
          */
         this.canvasContextAttributes = {};
-        /**
-         * The Timeout id used to track this canvas entry.
-         */
-        this.drawTimeout = null;
-
     }
 
     /**
@@ -130,27 +125,21 @@ export default class CanvasEntry {
      */
     clearWave() {
         // wave
-        this.waveCtx.save();
-        this.waveCtx.setTransform(1, 0, 0, 1, 0, 0);
         this.waveCtx.clearRect(
             0,
             0,
             this.waveCtx.canvas.width,
             this.waveCtx.canvas.height
         );
-        this.waveCtx.restore();
 
         // progress
         if (this.hasProgressCanvas) {
-            this.progressCtx.save();
-            this.progressCtx.setTransform(1, 0, 0, 1, 0, 0);
             this.progressCtx.clearRect(
                 0,
                 0,
                 this.progressCtx.canvas.width,
                 this.progressCtx.canvas.height
             );
-            this.progressCtx.restore();
         }
     }
 
@@ -433,38 +422,6 @@ export default class CanvasEntry {
             });
         } else if (type === 'dataURL') {
             return this.wave.toDataURL(format, quality);
-        }
-    }
-
-    /**
-     * Stretches existing canvas
-     * @param {Number} newTotalWidth total width of wave in pixels
-     */
-    stretchCanvas(newTotalWidth) {
-        //Calculate the start and width of this canvas
-        let start = Math.round(this.start * newTotalWidth);
-        let width = Math.round(this.end * newTotalWidth - start);
-
-        //Stretch canvas
-        let elementSize = { width: width + 'px' };
-        let elementStart = {left: start + 'px'};
-        style(this.wave, elementSize);
-        style(this.wave, elementStart);
-        if (this.hasProgressCanvas) {
-            style(this.progress, elementSize);
-            style(this.progress, elementStart);
-        }
-    }
-
-    /**
-     * Set the left offset of the canvas
-     * @param {Number} position in px for the canvas to start
-     */
-    setLeft(position) {
-        let elementStart = {left: position + 'px'};
-        style(this.wave, elementStart);
-        if (this.hasProgressCanvas) {
-            style(this.progress, elementStart);
         }
     }
 }

--- a/src/drawer.js
+++ b/src/drawer.js
@@ -272,6 +272,10 @@ export default class Drawer extends util.Observer {
      * @return {boolean} Whether the width of the container was updated or not
      */
     setWidth(width) {
+        if (this.width == width) {
+            return false;
+        }
+
         this.width = width;
 
         if (this.params.fillParent || this.params.scrollParent) {

--- a/src/drawer.multicanvas.js
+++ b/src/drawer.multicanvas.js
@@ -89,14 +89,6 @@ export default class MultiCanvas extends Drawer {
          * @type {boolean}
          */
         this.vertical = params.vertical;
-
-        /**
-         * Whether to use the optimsized zoom rendering
-         * Automatically toggles to true if stretchCanvases() function is called
-         *
-         * @type {boolean}
-         */
-        this.optimiseZoom = false;
     }
 
     /**
@@ -165,16 +157,10 @@ export default class MultiCanvas extends Drawer {
 
         let canvasWidth = this.maxCanvasWidth + this.overlap;
         const lastCanvas = this.canvases.length - 1;
-        let leftOffset = 0;
         this.canvases.forEach((entry, i) => {
             if (i == lastCanvas) {
                 canvasWidth = this.width - this.maxCanvasWidth * lastCanvas;
             }
-
-            //Set left offset and add to next entry
-            entry.setLeft(leftOffset);
-            leftOffset += canvasWidth / this.params.pixelRatio;
-
             this.updateDimensions(entry, canvasWidth, this.height);
 
             entry.clearWave();
@@ -424,39 +410,7 @@ export default class MultiCanvas extends Drawer {
         this.canvases.forEach((entry, i) => {
             this.setFillStyles(entry, waveColor, progressColor);
             this.applyCanvasTransforms(entry, this.params.vertical);
-
-            if (this.optimiseZoom) {
-                //Optimising zoom functionality
-                //If there's a wrapper, optimise for the view
-                let priority = 0;
-                if (this.wrapper) {
-                    let canvasRect = entry.wave.getBoundingClientRect();
-                    let wrapperRect = this.wrapper.getBoundingClientRect();
-
-                    //Determine whether canvas is in viewframe or not and assign priority
-                    if (Math.floor(canvasRect['left']) > Math.ceil(wrapperRect['right'])) {
-                        //Canvas is to the right of view window
-                        let distance = canvasRect['left'] - wrapperRect['right'];
-                        priority = Math.ceil(distance / wrapperRect['width']);
-                    } else if (Math.ceil(canvasRect['right']) < Math.floor(wrapperRect['left'])) {
-                        //Canvas is to the left of the view window
-                        let distance = wrapperRect['left'] - canvasRect['right'];
-                        priority = Math.ceil(distance / wrapperRect['width']);
-                    }
-                } else {
-                    //Everything is equal priority
-                }
-
-                //This staggers the drawing of canvases so they don't all draw at once
-                entry.clearWave();
-                clearTimeout(entry.drawTimeout);
-                entry.drawTimeout = setTimeout(function(){
-                    entry.drawLines(peaks, absmax, halfH, offsetY, start, end);
-                    entry.drawTimeout = null;
-                }, 25 * priority);
-            } else {
-                entry.drawLines(peaks, absmax, halfH, offsetY, start, end);
-            }
+            entry.drawLines(peaks, absmax, halfH, offsetY, start, end);
         });
     }
 
@@ -650,30 +604,6 @@ export default class MultiCanvas extends Drawer {
             );
             return images.length > 1 ? images : images[0];
         }
-    }
-
-    /**
-     * Stretches the canvases to mimic zoom without recalculation
-     *
-     * @param {Number} desiredWidth new width of the wave display
-     * @param {Number} progress Value between 0 and 1 for wave progress
-     */
-    stretchCanvases(desiredWidth, progress) {
-        if (!this.optimiseZoom) {
-            //Enable optimsed zooming
-            this.optimiseZoom = true;
-        }
-        let totalCanvasWidth = Math.round(desiredWidth / this.params.pixelRatio);
-        this.width = desiredWidth;
-
-        for (let i = 0; i < this.canvases.length; i++) {
-            this.canvases[i].stretchCanvas(totalCanvasWidth);
-        }
-
-        //Update progress
-        let progressPos = progress * totalCanvasWidth;
-        this.updateProgress(progressPos);
-        this.recenterOnPosition(progressPos, true);
     }
 
     /**

--- a/src/plugin/spectrogram/index.js
+++ b/src/plugin/spectrogram/index.js
@@ -92,9 +92,6 @@ export default class SpectrogramPlugin {
         this._onRender = () => {
             this.render();
         };
-        this._onZoom = () => {
-            this.stretchCanvases();
-        };
         this._onWrapperClick = e => {
             this._wrapperClickHandler(e);
         };
@@ -139,9 +136,6 @@ export default class SpectrogramPlugin {
             this.alpha = params.alpha;
             this.splitChannels = params.splitChannels;
             this.channels = this.splitChannels ? ws.backend.buffer.numberOfChannels : 1;
-            this.canvases = [];
-            this.canvasesTimeouts = [];
-            this.scrollLeftTracker = 0; //Tracks the desired scrollLeft value
 
             // Getting file's original samplerate is difficult(#1248).
             // So set 12kHz default to render like wavesurfer.js 5.x.
@@ -149,11 +143,10 @@ export default class SpectrogramPlugin {
             this.frequencyMax = params.frequencyMax || 12000;
 
             this.createWrapper();
-            this.addCanvas();
+            this.createCanvas();
             this.render();
 
             drawer.wrapper.addEventListener('scroll', this._onScroll);
-            ws.on('zoom', this._onZoom);
             ws.on('redraw', this._onRender);
         };
     }
@@ -238,49 +231,17 @@ export default class SpectrogramPlugin {
         this.fireEvent('click', relX / this.width || 0);
     }
 
-    /**
-     * Add a canvas to this.canvases
-     */
-    addCanvas() {
-        const canvas = (this.wrapper.appendChild(
+    createCanvas() {
+        const canvas = (this.canvas = this.wrapper.appendChild(
             document.createElement('canvas')
         ));
+
+        this.spectrCc = canvas.getContext('2d');
 
         this.util.style(canvas, {
             position: 'absolute',
             zIndex: 4
         });
-
-        this.canvases.push(canvas);
-        this.canvasesTimeouts.push(null);
-    }
-
-    /**
-     * Remove a canvas from this.canvases
-     */
-    removeCanvas() {
-        //Stop drawing (if drawing)
-        clearTimeout(this.canvasesTimeouts[this.canvasesTimeouts.length - 1]);
-
-        let lastEntry = this.canvases[this.canvases.length - 1];
-        lastEntry.parentElement.removeChild(lastEntry);
-
-        this.canvases.pop();
-        this.canvasesTimeouts.pop();
-    }
-
-    /**
-     * Ensure the correct number of canvases for the size of the spectrogram
-     */
-    updateCanvases() {
-        let canvasesRequired = Math.ceil(this.width / 4000);
-
-        while (this.canvases.length < canvasesRequired) {
-            this.addCanvas();
-        }
-        while (this.canvases.length > canvasesRequired) {
-            this.removeCanvas();
-        }
     }
 
     render() {
@@ -294,14 +255,11 @@ export default class SpectrogramPlugin {
     }
 
     updateCanvasStyle() {
-        this.updateCanvases();
-        //width per canvas
-        for (let i = 0; i < this.canvases.length; i++) {
-            this.canvases[i].width = Math.round(this.width / this.canvases.length);
-            this.canvases[i].height = this.fftSamples / 2 * this.channels;
-            this.canvases[i].style.width = Math.round(this.canvases[i].width / this.pixelRatio) + 'px';
-            this.canvases[i].style.height = this.height + 'px';
-        }
+        const width = Math.round(this.width / this.pixelRatio) + 'px';
+        this.canvas.width = this.width;
+        this.canvas.height = this.fftSamples / 2 * this.channels;
+        this.canvas.style.width = width;
+        this.canvas.style.height = this.height + 'px';
     }
 
     drawSpectrogram(frequenciesData, my) {
@@ -310,61 +268,25 @@ export default class SpectrogramPlugin {
             frequenciesData = [frequenciesData];
         }
 
-        my.updateCanvasStyle();
-
-        //Stop canvases still being drawn
-        for (let i = 0; i < my.canvasesTimeouts.length; i++) {
-            clearTimeout(my.canvasesTimeouts[i]);
-        }
-
-        const view = [my.scrollLeftTracker, my.scrollLeftTracker + my.wrapper.clientWidth];
-
-        for (let canvasNum = 0; canvasNum < my.canvases.length; canvasNum++) {
-            const canvasLeft = canvasNum * Math.floor(my.width / my.canvases.length / my.pixelRatio);
-            const canvasRight = (canvasNum + 1) * Math.floor(my.width / my.canvases.length / my.pixelRatio);
-            const canvasBound = [canvasLeft, canvasRight];
-            my.canvases[canvasNum].style['left'] = canvasLeft + 'px';
-
-            //Optimise drawing for the view
-            let priority = 0;
-            if (canvasBound[0] > view[1]) {
-                //Canvas is to the right of view window
-                let distance = canvasBound[0] - view[1];
-                priority = Math.ceil(distance / (view[1] - view[0]));
-            } else if (canvasBound[1] < view[0]) {
-                //Canvas is to the left of the view window
-                let distance = view[0] - canvasBound[1];
-                priority = Math.ceil(distance / (view[1] - view[0]));
-            }
-
-            //delay = 25ms * number of viewport widths away the canvas is
-            my.canvasesTimeouts[canvasNum] = setTimeout(my.drawToCanvas, 25 * priority, frequenciesData, my, canvasNum);
-        }
-    }
-
-    /**
-     * Draw spectrogram channel to a specific canvas
-     * @param {[Number, Number, Number]} frequenciesData spectrogram data in [channel, sample, freq] format
-     * @param {SpectrogramPlugin} my variable with 'this' in it
-     * @param {Number} canvasNum Canvas to draw to
-     */
-    drawToCanvas(frequenciesData, my, canvasNum) {
+        const spectrCc = my.spectrCc;
         const height = my.fftSamples / 2;
+        const width = my.width;
         const freqFrom = my.buffer.sampleRate / 2;
         const freqMin = my.frequencyMin;
         const freqMax = my.frequencyMax;
 
-        for (let channel = 0; channel < frequenciesData.length; channel++) {
+        if (!spectrCc) {
+            return;
+        }
 
-            //Get pixels from frequency data and apply to image
-            const relevantFreqs = frequenciesData[channel].slice(canvasNum * Math.round(frequenciesData[channel].length / my.canvases.length), (canvasNum + 1) * Math.round(frequenciesData[channel].length / my.canvases.length));
-            const pixels = my.resample(relevantFreqs);
-            const imageData = new ImageData(pixels.length, height);
+        for (let c = 0; c < frequenciesData.length; c++) { // for each channel
+            const pixels = my.resample(frequenciesData[c]);
+            const imageData = new ImageData(width, height);
 
             for (let i = 0; i < pixels.length; i++) {
                 for (let j = 0; j < pixels[i].length; j++) {
                     const colorMap = my.colorMap[pixels[i][j]];
-                    const redIndex = ((height - j) * imageData.width + i) * 4;
+                    const redIndex = ((height - j) * width + i) * 4;
                     imageData.data[redIndex] = colorMap[0] * 255;
                     imageData.data[redIndex + 1] = colorMap[1] * 255;
                     imageData.data[redIndex + 2] = colorMap[2] * 255;
@@ -372,20 +294,16 @@ export default class SpectrogramPlugin {
                 }
             }
 
-            //Draw image to canvas
-            createImageBitmap(imageData).then(renderer => {
-                if (my.canvases[canvasNum]) { //Check canvas still exists after creating image
-                    my.canvases[canvasNum].getContext('2d').drawImage(renderer,
-                        0, height * (1 - freqMax / freqFrom), // source x, y
-                        imageData.width, height * (freqMax - freqMin) / freqFrom, // source width, height
-                        0, height * channel, // destination x, y
-                        my.canvases[canvasNum].width, height // destination width, height
-                    );
-                }
-            });
+            // scale and stack spectrograms
+            createImageBitmap(imageData).then(renderer =>
+                spectrCc.drawImage(renderer,
+                    0, height * (1 - freqMax / freqFrom), // source x, y
+                    width, height * (freqMax - freqMin) / freqFrom, // source width, height
+                    0, height * c, // destination x, y
+                    width, height // destination width, height
+                )
+            );
         }
-        //Drawing is finished
-        my.canvasesTimeouts[canvasNum] = null;
     }
 
     getFrequencies(callback) {
@@ -404,7 +322,7 @@ export default class SpectrogramPlugin {
 
         let noverlap = this.noverlap;
         if (!noverlap) {
-            const uniqueSamplesPerPx = buffer.length / this.width;
+            const uniqueSamplesPerPx = buffer.length / this.canvas.width;
             noverlap = Math.max(0, Math.round(fftSamples - uniqueSamplesPerPx));
         }
 
@@ -543,13 +461,12 @@ export default class SpectrogramPlugin {
 
     updateScroll(e) {
         if (this.wrapper) {
-            this.scrollLeftTracker = e.target.scrollLeft;
             this.wrapper.scrollLeft = e.target.scrollLeft;
         }
     }
 
     resample(oldMatrix) {
-        const columnsNumber = oldMatrix.length;
+        const columnsNumber = this.width;
         const newMatrix = [];
 
         const oldPiece = 1 / oldMatrix.length;
@@ -601,13 +518,5 @@ export default class SpectrogramPlugin {
         }
 
         return newMatrix;
-    }
-
-    stretchCanvases() {
-        for (let i = 0; i < this.canvases.length; i++) {
-            this.canvases[i].style.width = Math.round(this.drawer.width / this.canvases.length / this.pixelRatio) + 'px';
-            const canvasLeft = i * Math.floor(this.drawer.width / this.canvases.length / this.pixelRatio);
-            this.canvases[i].style['left'] = canvasLeft + 'px';
-        }
     }
 }

--- a/src/wavesurfer.js
+++ b/src/wavesurfer.js
@@ -1276,21 +1276,6 @@ export default class WaveSurfer extends util.Observer {
     }
 
     /**
-     * Calls getPeaks() and drawPeaks()
-     * @param {WaveSurfer} wavesurfer the Wavesurfer to get/draw peaks from/to
-     * @param {number} width The width of the area that should be drawn
-     * @param {number} start The x-offset of the beginning of the area that
-     * should be rendered
-     * @param {number} end The x-offset of the end of the area that should be
-     * rendered
-     */
-    getAndDrawPeaks(wavesurfer, width, start, end) {
-        let peaks;
-        peaks = wavesurfer.backend.getPeaks(width, start, end);
-        wavesurfer.drawer.drawPeaks(peaks, width, start, end);
-    }
-
-    /**
      * Get the correct peaks for current wave view-port and render wave
      *
      * @private
@@ -1368,24 +1353,6 @@ export default class WaveSurfer extends util.Observer {
         this.drawer.progress(this.backend.getPlayedPercents());
 
         this.drawer.recenter(this.getCurrentTime() / this.getDuration());
-        this.fireEvent('zoom', pxPerSec);
-    }
-
-    /**
-     * Call this function while moving the zoom slider to stretch the canvases
-     * of the wave without recalculating
-     *
-     * @param {Number} pxPerSec value returned from the zoom slider
-     */
-    zooming(pxPerSec) {
-        //Calculate the new width, this cannot be smaller than the parent container width
-        let desiredWidth = Math.round(this.getDuration() * pxPerSec * this.params.pixelRatio);
-        let parentWidth = this.drawer.getWidth();
-        desiredWidth = Math.max(parentWidth, desiredWidth);
-
-        //Stretch canvases
-        this.drawer.stretchCanvases(desiredWidth, this.backend.getPlayedPercents());
-
         this.fireEvent('zoom', pxPerSec);
     }
 


### PR DESCRIPTION
As requested in #2741, a separate PR to revert "Zoom optimisation" (#2646).

Resolves #2738.

As @kai-shimada found out, v6.6.0 introduced a regression in width calculation. The only likely cause is https://github.com/wavesurfer-js/wavesurfer.js/pull/2646, so I suggest we revert it for now.