### PR TITLE
Release 6.6.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 wavesurfer.js changelog
 =======================
 
+6.6.2 (24.03.2023)
+------------------
+- Revert "Zoom optimisation for Waves and matching implementation for Spectrograms (#2646)"
+- Fix: avoid exit 1 in CI script (#2734)
+
 6.6.1 (18.03.2023)
 ------------------
 - Fix: NPM publish in the CI job (#2727)

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "homepage": "https://wavesurfer-js.org",
   "authors": [
     "katspaugh <katspaugh@gmail.com>"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wavesurfer.js",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "description": "Interactive navigable audio visualization using Web Audio and Canvas",
   "main": "dist/wavesurfer.js",
   "directories": {


### PR DESCRIPTION
This PR only updates package.json and the changelog on master. The release itself has already been [published](https://github.com/wavesurfer-js/wavesurfer.js/releases/tag/6.6.2) at an earlier snapshot of master w/o an unwanted commit that is currently on master (it will go live in another release).