### PR TITLE
Docs: version the unpkg script in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import WaveSurfer from 'wavesurfer.js'
 
 If you're not using a package manager, simply insert the script from a CDN:
 ```
-<script src="https://unpkg.com/wavesurfer.js"></script>
+<script src="https://unpkg.com/wavesurfer.js@6.6"></script>
 ```
 
 Create a container in your HTML:


### PR DESCRIPTION
With the unpkg CDN, when the version is omitted, it will fetch the latest version published on NPM.

In our readme, we provide a CDN tag with the an unspecified version, as a way to keep users up-to-date.

However, if we release a major version update, e.g. 7.0.0, people who copied and pasted the unpkg tag from our readme, will have wavesurfer.js updated to that version, even though a major version update implies breaking changes.

Capping the version at `wavesurfer.js@6` would prevent users from unknowingly auto-upgrading with _intentional_ breaking changes.

Beaking changes or regressions can also occur _unintentionally_ (as was the case with 6.6.0), so pinning the minor version would be the safest (while still fetching bug fixes automatically).

The tag in the readme is obviously just a recommendation, and users can choose a different versioning strategy in their app.
