### PR TITLE
Remove marker by id

### DIFF
--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -167,8 +167,7 @@ export default class MarkersPlugin {
             color: params.color || DEFAULT_FILL_COLOR,
             position: params.position || DEFAULT_POSITION,
             draggable: !!params.draggable,
-            preventContextMenu: !!params.preventContextMenu,
-            id: params.id || this.util.getId("marker-")
+            preventContextMenu: !!params.preventContextMenu
         };
 
         marker.el = this._createMarkerElement(marker, params.markerElement);
@@ -184,23 +183,15 @@ export default class MarkersPlugin {
 
 
     /**
-     * Removes a marker by ID
-     * Uses remove(index) internally
-     *
-     * @param {string} id Id of the marker to remove
-     */
-
-    removeById(id) {
-        let markerIndex = this.markers.findIndex(marker => marker.id === id);
-        this.remove(markerIndex);
-    }
-
-    /**
      * Remove a marker
      *
-     * @param {number} index Index of the marker to remove
+     * @param {number|Object} indexOrMarker Index of the marker to remove or the marker object itself
      */
-    remove(index) {
+    remove(indexOrMarker) {
+        let index = indexOrMarker;
+        if (isNaN(index)) {
+            index = this.markers.findIndex(marker => marker === indexOrMarker);
+        }
         let marker = this.markers[index];
         if (!marker) {
             return;

--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -167,7 +167,8 @@ export default class MarkersPlugin {
             color: params.color || DEFAULT_FILL_COLOR,
             position: params.position || DEFAULT_POSITION,
             draggable: !!params.draggable,
-            preventContextMenu: !!params.preventContextMenu
+            preventContextMenu: !!params.preventContextMenu,
+            id: params.id || this.util.getId("marker-")
         };
 
         marker.el = this._createMarkerElement(marker, params.markerElement);
@@ -179,6 +180,19 @@ export default class MarkersPlugin {
         this._registerEvents();
 
         return marker;
+    }
+
+
+    /**
+     * Removes a marker by ID
+     * Uses remove(index) internally
+     *
+     * @param {string} id Id of the marker to remove
+     */
+
+    removeById(id) {
+        let markerIndex = this.markers.findIndex(marker => marker.id === id);
+        this.remove(markerIndex);
     }
 
     /**

--- a/src/plugin/markers/index.js
+++ b/src/plugin/markers/index.js
@@ -181,7 +181,6 @@ export default class MarkersPlugin {
         return marker;
     }
 
-
     /**
      * Remove a marker
      *


### PR DESCRIPTION
Markers plugin has a method called remove(idx) which removes one marker at index idx in the markers array in wavesurfer's markers object.
To remove a marker, we have to find the index of marker to remove by matching time, or label. This, I think can be improved because two markers can have same time and/or label.

Changes here introduce an id to each marker and a function removeById(id) which will find the index of marker with that id and call remove(idx)

related: see #2748 
